### PR TITLE
use PPB(scale of 9) as the base unit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,14 +76,11 @@ linters:
 #   skip-files:
 #     - internal/cache/.*_test.go
 
-# issues:
-#   exclude-rules:
-#     - path: internal/(cache|renameio)/
-#       linters:
-#         - lll
-#         - gochecknoinits
-#         - gocyclo
-#         - funlen
+issues:
+  exclude-rules:
+    - path: ".*_test.go"
+      linters:
+        - dupl
 
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration

--- a/bps/bps.go
+++ b/bps/bps.go
@@ -7,7 +7,8 @@ type unit int
 
 // List of values that `unit` can take.
 const (
-	PPM unit = iota + 1
+	PPB unit = iota + 1
+	PPM
 	DeciBasisPoint
 	HalfBasisPoint
 	BasisPoint

--- a/bps/bps_test.go
+++ b/bps/bps_test.go
@@ -17,6 +17,11 @@ func TestBPS_String_Default_BaseUnit(t *testing.T) {
 		want string
 	}{
 		{
+			"1 ppb presents `0` as string",
+			bps.NewFromPPB(big.NewInt(1)),
+			"0",
+		},
+		{
 			"1 ppm presents `0` as string",
 			bps.NewFromPPM(big.NewInt(1)),
 			"0",
@@ -79,6 +84,10 @@ func ExampleString() {
 	bps.BaseUnit = bps.PPM
 	fmt.Println(b)
 
+	// Update BaseUnit to output as ppms
+	bps.BaseUnit = bps.PPB
+	fmt.Println(b)
+
 	// teardown
 	bps.BaseUnit = u
 	// Output:
@@ -86,4 +95,5 @@ func ExampleString() {
 	// 1500
 	// 15
 	// 150000
+	// 150000000
 }

--- a/bps/bps_test.go
+++ b/bps/bps_test.go
@@ -11,50 +11,42 @@ import (
 func TestBPS_String_Default_BaseUnit(t *testing.T) {
 	t.Log("The default BaseUnit is DeciBasisPoint")
 
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		want string
 	}{
-		{
-			"1 ppb presents `0` as string",
+		"1 ppb presents `0` as string": {
 			bps.NewFromPPB(big.NewInt(1)),
 			"0",
 		},
-		{
-			"1 ppm presents `0` as string",
+		"1 ppm presents `0` as string": {
 			bps.NewFromPPM(big.NewInt(1)),
 			"0",
 		},
-		{
-			"1 deci basis point presents `1` as string",
+		"1 deci basis point presents `1` as string": {
 			bps.NewFromDeciBasisPoint(1),
 			"1",
 		},
-		{
-			"1 basis point presents `10` as string",
+		"1 basis point presents `10` as string": {
 			bps.NewFromBasisPoint(1),
 			"10",
 		},
-		{
-			"1 percentage presents `1000` as string",
+		"1 percentage presents `1000` as string": {
 			bps.NewFromPercentage(1),
 			"1000",
 		},
-		{
-			"1 amount presents `100000` as string",
+		"1 amount presents `100000` as string": {
 			bps.NewFromAmount(1),
 			"100000",
 		},
-		{
-			"nil presents `0` as string",
+		"nil presents `0` as string": {
 			&bps.BPS{},
 			"0",
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := tt.b.String(); got != tt.want {
 				t.Errorf("BPS.String() = %v, want %v", got, tt.want)

--- a/bps/calc_test.go
+++ b/bps/calc_test.go
@@ -182,10 +182,10 @@ func TestBPS_Div(t *testing.T) {
 			bps.NewFromPPM(big.NewInt(25)),
 		},
 		{
-			"100 ppms / 3 = 33 ppms, truncates after the decimal point",
+			"100 ppms / 3 = 33.333 ppms  = 33,333 ppbs, truncates after the decimal point",
 			bps.NewFromPPM(big.NewInt(100)),
 			3,
-			bps.NewFromPPM(big.NewInt(33)),
+			bps.NewFromPPB(big.NewInt(33333)),
 		},
 		{
 			"100 ppms / -5 = -20 ppms",
@@ -398,22 +398,22 @@ func TestAvg(t *testing.T) {
 		want  *bps.BPS
 	}{
 		{
-			"the average of 50 basis points, 125 basis points, and 345 basis points is 17,333 ppms rounded off",
+			"the average of 50 basis points, 125 basis points, and 345 basis points is 17,333,333 ppbs rounded off",
 			bps.NewFromBasisPoint(50),
 			[]*bps.BPS{
 				bps.NewFromBasisPoint(125),
 				bps.NewFromBasisPoint(345),
 			},
-			bps.NewFromPPM(big.NewInt(17333)),
+			bps.NewFromPPB(big.NewInt(17333333)),
 		},
 		{
-			"the average of 3 percentages, 2 amounts, and 50 basis points is 6783,333 ppms rounded off",
+			"the average of 3 percentages, 2 amounts, and 50 basis points is 6783,333,333 ppbs rounded off",
 			bps.NewFromPercentage(3),
 			[]*bps.BPS{
 				bps.NewFromAmount(2),
 				bps.NewFromBasisPoint(50),
 			},
-			bps.NewFromPPM(big.NewInt(678333)),
+			bps.NewFromPPB(big.NewInt(678333333)),
 		},
 		{
 			"the average of 3 deci basis points, 15 percentages, and -360 basis points is 3801 deci basis points",
@@ -425,13 +425,13 @@ func TestAvg(t *testing.T) {
 			bps.NewFromDeciBasisPoint(3801),
 		},
 		{
-			"the average of 50 basis points, 125 basis points, and nil is 5,833 ppms rounded off",
+			"the average of 50 basis points, 125 basis points, and nil is 5,833,333 ppbs rounded off",
 			bps.NewFromBasisPoint(50),
 			[]*bps.BPS{
 				bps.NewFromBasisPoint(125),
 				{},
 			},
-			bps.NewFromPPM(big.NewInt(5833)),
+			bps.NewFromPPB(big.NewInt(5833333)),
 		},
 	}
 	for _, tt := range tests {

--- a/bps/calc_test.go
+++ b/bps/calc_test.go
@@ -9,46 +9,40 @@ import (
 )
 
 func TestBPS_Add(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		b2   *bps.BPS
 		want *bps.BPS
 	}{
-		{
-			"1 basis point + 1 percentage = 10,100 ppms",
+		"1 basis point + 1 percentage = 10,100 ppms": {
 			bps.NewFromBasisPoint(1),
 			bps.NewFromPercentage(1),
 			bps.NewFromPPM(big.NewInt(10100)),
 		},
-		{
-			"50 ppms + 1 deci basis point = 60 ppms",
+		"50 ppms + 1 deci basis point = 60 ppms": {
 			bps.NewFromPPM(big.NewInt(50)),
 			bps.NewFromDeciBasisPoint(1),
 			bps.NewFromPPM(big.NewInt(60)),
 		},
-		{
-			"1 deci basis point + (-1) basis point = -90 ppms",
+		"1 deci basis point + (-1) basis point = -90 ppms": {
 			bps.NewFromDeciBasisPoint(1),
 			bps.NewFromBasisPoint(-1),
 			bps.NewFromPPM(big.NewInt(-90)),
 		},
-		{
-			"nil + 1 ppm = 1 ppms",
+		"nil + 1 ppm = 1 ppms": {
 			&bps.BPS{},
 			bps.NewFromPPM(big.NewInt(1)),
 			bps.NewFromPPM(big.NewInt(1)),
 		},
-		{
-			"1 ppm + nil = 1 ppms",
+		"1 ppm + nil = 1 ppms": {
 			bps.NewFromPPM(big.NewInt(1)),
 			&bps.BPS{},
 			bps.NewFromPPM(big.NewInt(1)),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.Add(tt.b2)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -73,46 +67,40 @@ func assertImmutableOperation(t *testing.T, msg string, got, receiver *bps.BPS, 
 }
 
 func TestBPS_Sub(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		b2   *bps.BPS
 		want *bps.BPS
 	}{
-		{
-			"1 amount - 10 percentages = 900,000 ppms",
+		"1 amount - 10 percentages = 900,000 ppms": {
 			bps.NewFromAmount(1),
 			bps.NewFromPercentage(10),
 			bps.NewFromPPM(big.NewInt(900000)),
 		},
-		{
-			"1 amount - (-10) percentages = 1100,000 ppms",
+		"1 amount - (-10) percentages = 1100,000 ppms": {
 			bps.NewFromAmount(1),
 			bps.NewFromPercentage(-10),
 			bps.NewFromPPM(big.NewInt(1100000)),
 		},
-		{
-			"1 basis point - 10 deci basis point = 0",
+		"1 basis point - 10 deci basis point = 0": {
 			bps.NewFromBasisPoint(1),
 			bps.NewFromDeciBasisPoint(10),
 			bps.NewFromAmount(0),
 		},
-		{
-			"nil - 1 ppm = -1 ppm",
+		"nil - 1 ppm = -1 ppm": {
 			&bps.BPS{},
 			bps.NewFromPPM(big.NewInt(1)),
 			bps.NewFromPPM(big.NewInt(-1)),
 		},
-		{
-			"1 ppm - nil = 1 ppm",
+		"1 ppm - nil = 1 ppm": {
 			bps.NewFromPPM(big.NewInt(1)),
 			&bps.BPS{},
 			bps.NewFromPPM(big.NewInt(1)),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.Sub(tt.b2)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -124,40 +112,35 @@ func TestBPS_Sub(t *testing.T) {
 }
 
 func TestBPS_Mul(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		arg  int64
 		want *bps.BPS
 	}{
-		{
-			"1 basis point * 5 = 500 ppms",
+		"1 basis point * 5 = 500 ppms": {
 			bps.NewFromBasisPoint(1),
 			5,
 			bps.NewFromPPM(big.NewInt(500)),
 		},
-		{
-			"1 deci basis point * (-10) = -100 ppms",
+		"1 deci basis point * (-10) = -100 ppms": {
 			bps.NewFromDeciBasisPoint(1),
 			-10,
 			bps.NewFromPPM(big.NewInt(-100)),
 		},
-		{
-			"-1 percentage * 2 = -20,000 ppms",
+		"-1 percentage * 2 = -20,000 ppms": {
 			bps.NewFromPercentage(-1),
 			2,
 			bps.NewFromPPM(big.NewInt(-20000)),
 		},
-		{
-			"nil * 1 = 0",
+		"nil * 1 = 0": {
 			&bps.BPS{},
 			1,
 			bps.NewFromAmount(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.Mul(tt.arg)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -169,40 +152,35 @@ func TestBPS_Mul(t *testing.T) {
 }
 
 func TestBPS_Div(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		arg  int64
 		want *bps.BPS
 	}{
-		{
-			"100 ppms / 4 = 25 ppms",
+		"100 ppms / 4 = 25 ppms": {
 			bps.NewFromPPM(big.NewInt(100)),
 			4,
 			bps.NewFromPPM(big.NewInt(25)),
 		},
-		{
-			"100 ppms / 3 = 33.333 ppms  = 33,333 ppbs, truncates after the decimal point",
+		"100 ppms / 3 = 33.333 ppms  = 33,333 ppbs, truncates after the decimal point": {
 			bps.NewFromPPM(big.NewInt(100)),
 			3,
 			bps.NewFromPPB(big.NewInt(33333)),
 		},
-		{
-			"100 ppms / -5 = -20 ppms",
+		"100 ppms / -5 = -20 ppms": {
 			bps.NewFromPPM(big.NewInt(100)),
 			-5,
 			bps.NewFromPPM(big.NewInt(-20)),
 		},
-		{
-			"nil / 5 = 0 ppms",
+		"nil / 5 = 0 ppms": {
 			&bps.BPS{},
 			5,
 			bps.NewFromPPM(big.NewInt(0)),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.Div(tt.arg)
 			if !reflect.DeepEqual(got, tt.want) {
@@ -278,14 +256,12 @@ func TestBPS_Compare(t *testing.T) {
 }
 
 func TestSum(t *testing.T) {
-	tests := []struct {
-		name  string
+	tests := map[string]struct {
 		first *bps.BPS
 		rest  []*bps.BPS
 		want  *bps.BPS
 	}{
-		{
-			"1 amount + 1 percentage + 1 basis point + 1 deci basis point + 1 ppm + empty + nil = 1010,111 ppms",
+		"1 amount + 1 percentage + 1 basis point + 1 deci basis point + 1 ppm + empty + nil = 1010,111 ppms": {
 			bps.NewFromAmount(1),
 			[]*bps.BPS{
 				bps.NewFromPercentage(1),
@@ -297,8 +273,7 @@ func TestSum(t *testing.T) {
 			},
 			bps.NewFromPPM(big.NewInt(1010111)),
 		},
-		{
-			"1 amount + (-1) percentage + (-1) basis point + (-1) deci basis point + (-1) ppm = 989,889 ppms",
+		"1 amount + (-1) percentage + (-1) basis point + (-1) deci basis point + (-1) ppm = 989,889 ppms": {
 			bps.NewFromAmount(1),
 			[]*bps.BPS{
 				bps.NewFromPercentage(-1),
@@ -309,9 +284,9 @@ func TestSum(t *testing.T) {
 			bps.NewFromPPM(big.NewInt(989889)),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := bps.Sum(tt.first, tt.rest...); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Sum() = %v, want %v", got, tt.want)
@@ -321,30 +296,26 @@ func TestSum(t *testing.T) {
 }
 
 func TestBPS_Abs(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		want *bps.BPS
 	}{
-		{
-			"If plus value, it should return the same value",
+		"If plus value, it should return the same value": {
 			bps.NewFromAmount(1),
 			bps.NewFromAmount(1),
 		},
-		{
-			"If minus value, it should return the plus value",
+		"If minus value, it should return the plus value": {
 			bps.NewFromAmount(-1),
 			bps.NewFromAmount(1),
 		},
-		{
-			"If nil, it should retrun zero",
+		"If nil, it should retrun zero": {
 			&bps.BPS{},
 			bps.NewFromAmount(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.Abs()
 			if !reflect.DeepEqual(got, tt.want) {
@@ -356,30 +327,26 @@ func TestBPS_Abs(t *testing.T) {
 }
 
 func TestBPS_Neg(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		want *bps.BPS
 	}{
-		{
-			"If plus value, it should return the minus value",
+		"If plus value, it should return the minus value": {
 			bps.NewFromAmount(1),
 			bps.NewFromAmount(-1),
 		},
-		{
-			"If minus value, it should return the plus value",
+		"If minus value, it should return the plus value": {
 			bps.NewFromAmount(-1),
 			bps.NewFromAmount(1),
 		},
-		{
-			"If nil, it should return zero",
+		"If nil, it should return zero": {
 			&bps.BPS{},
 			bps.NewFromAmount(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.b.Neg()
 			if !reflect.DeepEqual(got, tt.want) {
@@ -391,14 +358,12 @@ func TestBPS_Neg(t *testing.T) {
 }
 
 func TestAvg(t *testing.T) {
-	tests := []struct {
-		name  string
+	tests := map[string]struct {
 		first *bps.BPS
 		rest  []*bps.BPS
 		want  *bps.BPS
 	}{
-		{
-			"the average of 50 basis points, 125 basis points, and 345 basis points is 17,333,333 ppbs rounded off",
+		"the average of 50 basis points, 125 basis points, and 345 basis points is 17,333,333 ppbs rounded off": {
 			bps.NewFromBasisPoint(50),
 			[]*bps.BPS{
 				bps.NewFromBasisPoint(125),
@@ -406,8 +371,7 @@ func TestAvg(t *testing.T) {
 			},
 			bps.NewFromPPB(big.NewInt(17333333)),
 		},
-		{
-			"the average of 3 percentages, 2 amounts, and 50 basis points is 6783,333,333 ppbs rounded off",
+		"the average of 3 percentages, 2 amounts, and 50 basis points is 6783,333,333 ppbs rounded off": {
 			bps.NewFromPercentage(3),
 			[]*bps.BPS{
 				bps.NewFromAmount(2),
@@ -415,8 +379,7 @@ func TestAvg(t *testing.T) {
 			},
 			bps.NewFromPPB(big.NewInt(678333333)),
 		},
-		{
-			"the average of 3 deci basis points, 15 percentages, and -360 basis points is 3801 deci basis points",
+		"the average of 3 deci basis points, 15 percentages, and -360 basis points is 3801 deci basis points": {
 			bps.NewFromDeciBasisPoint(3),
 			[]*bps.BPS{
 				bps.NewFromPercentage(15),
@@ -424,8 +387,7 @@ func TestAvg(t *testing.T) {
 			},
 			bps.NewFromDeciBasisPoint(3801),
 		},
-		{
-			"the average of 50 basis points, 125 basis points, and nil is 5,833,333 ppbs rounded off",
+		"the average of 50 basis points, 125 basis points, and nil is 5,833,333 ppbs rounded off": {
 			bps.NewFromBasisPoint(50),
 			[]*bps.BPS{
 				bps.NewFromBasisPoint(125),
@@ -434,9 +396,9 @@ func TestAvg(t *testing.T) {
 			bps.NewFromPPB(big.NewInt(5833333)),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := bps.Avg(tt.first, tt.rest...); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Avg() = %v, want %v", got, tt.want)
@@ -446,14 +408,12 @@ func TestAvg(t *testing.T) {
 }
 
 func TestMax(t *testing.T) {
-	tests := []struct {
-		name  string
+	tests := map[string]struct {
 		first *bps.BPS
 		rest  []*bps.BPS
 		want  *bps.BPS
 	}{
-		{
-			"the maximum value of 10 basis points, 99 deci basis points, nil, and 1001 ppms is 1001 ppms",
+		"the maximum value of 10 basis points, 99 deci basis points, nil, and 1001 ppms is 1001 ppms": {
 			bps.NewFromBasisPoint(10),
 			[]*bps.BPS{
 				bps.NewFromDeciBasisPoint(99),
@@ -462,8 +422,7 @@ func TestMax(t *testing.T) {
 			},
 			bps.NewFromPPM(big.NewInt(1001)),
 		},
-		{
-			"the maximum value of -10 basis points, -99 deci basis points, and -1001 ppms is -99 deci basis points",
+		"the maximum value of -10 basis points, -99 deci basis points, and -1001 ppms is -99 deci basis points": {
 			bps.NewFromBasisPoint(-10),
 			[]*bps.BPS{
 				bps.NewFromDeciBasisPoint(-99),
@@ -472,9 +431,9 @@ func TestMax(t *testing.T) {
 			bps.NewFromDeciBasisPoint(-99),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := bps.Max(tt.first, tt.rest...); !got.Equal(tt.want) {
 				t.Errorf("Max() = %v, want %v", got, tt.want)
@@ -484,14 +443,12 @@ func TestMax(t *testing.T) {
 }
 
 func TestMin(t *testing.T) {
-	tests := []struct {
-		name  string
+	tests := map[string]struct {
 		fisrt *bps.BPS
 		rest  []*bps.BPS
 		want  *bps.BPS
 	}{
-		{
-			"the minimum value of 10 basis points, 99 deci basis points, nil, and 1001 ppms is 0 ppms",
+		"the minimum value of 10 basis points, 99 deci basis points, nil, and 1001 ppms is 0 ppms": {
 			bps.NewFromBasisPoint(10),
 			[]*bps.BPS{
 				bps.NewFromDeciBasisPoint(99),
@@ -500,8 +457,7 @@ func TestMin(t *testing.T) {
 			},
 			bps.NewFromAmount(0),
 		},
-		{
-			"the minimum value of -10 basis points, -99 deci basis points, and -1001 ppms is -1001 deci basis points",
+		"the minimum value of -10 basis points, -99 deci basis points, and -1001 ppms is -1001 deci basis points": {
 			bps.NewFromBasisPoint(-10),
 			[]*bps.BPS{
 				bps.NewFromDeciBasisPoint(-99),
@@ -510,9 +466,9 @@ func TestMin(t *testing.T) {
 			bps.NewFromPPM(big.NewInt(-1001)),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := bps.Min(tt.fisrt, tt.rest...); !got.Equal(tt.want) {
 				t.Errorf("Min() = %v, want %v", got, tt.want)
@@ -522,70 +478,60 @@ func TestMin(t *testing.T) {
 }
 
 func TestBPS_FloatString(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		prec int
 		want string
 	}{
-		{
-			"1 ppm presents `0` as string",
+		"1 ppm presents `0` as string": {
 			bps.NewFromPPM(big.NewInt(1)),
 			0,
 			"0",
 		},
-		{
-			"1 ppm presents `0.000001` as string",
+		"1 ppm presents `0.000001` as string": {
 			bps.NewFromPPM(big.NewInt(1)),
 			6,
 			"0.000001",
 		},
-		{
-			"1 deci basis point presents `0.00001` as string",
+		"1 deci basis point presents `0.00001` as string": {
 			bps.NewFromDeciBasisPoint(1),
 			5,
 			"0.00001",
 		},
-		{
-			"1 deci basis point presents `0.000010` as string",
+		"1 deci basis point presents `0.000010` as string": {
 			bps.NewFromDeciBasisPoint(1),
 			6,
 			"0.000010",
 		},
-		{
-			"1 basis point presents `0.0001` as string",
+		"1 basis point presents `0.0001` as string": {
 			bps.NewFromBasisPoint(1),
 			4,
 			"0.0001",
 		},
-		{
-			"1 percentage presents `0.01` as string",
+		"1 percentage presents `0.01` as string": {
 			bps.NewFromPercentage(1),
 			2,
 			"0.01",
 		},
-		{
-			"5 percentage presents `0.1` as string, rounded to nearest",
+		"5 percentage presents `0.1` as string, rounded to nearest": {
 			bps.NewFromPercentage(5),
 			1,
 			"0.1",
 		},
-		{
-			"1 amount presents `1` as string",
+		"1 amount presents `1` as string": {
 			bps.NewFromAmount(1),
 			0,
 			"1",
 		},
-		{
-			"1 amount presents `1.0` as string",
+		"1 amount presents `1.0` as string": {
 			bps.NewFromAmount(1),
 			1,
 			"1.0",
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := tt.b.FloatString(tt.prec); got != tt.want {
 				t.Errorf("BPS.FloatString() = %v, want %v", got, tt.want)

--- a/bps/construct.go
+++ b/bps/construct.go
@@ -9,7 +9,8 @@ import (
 
 // Denominators for each parts
 const (
-	DenomDeciBasisPoint int64 = 10
+	DenomPPM            int64 = 1000
+	DenomDeciBasisPoint       = DenomPPM * 10
 	DenomHalfBasisPoint       = DenomDeciBasisPoint * 5
 	DenomBasisPoint           = DenomHalfBasisPoint * 2
 	DenomPercentage           = DenomBasisPoint * 100
@@ -55,9 +56,14 @@ func MustFromString(value string) *BPS {
 	return b
 }
 
+// NewFromPPB makes new BPS instance from part per billion(ppb)
+func NewFromPPB(ppb *big.Int) *BPS {
+	return newBPS(ppb)
+}
+
 // NewFromPPM makes new BPS instance from part per million(ppm)
 func NewFromPPM(ppm *big.Int) *BPS {
-	return newBPS(ppm)
+	return newBPS(ppm).Mul(DenomPPM)
 }
 
 // NewFromDeciBasisPoint makes new BPS instance from deci basis point
@@ -97,9 +103,11 @@ func NewFromBaseUnit(v int64) *BPS {
 		return NewFromBasisPoint(v)
 	case Percentage:
 		return NewFromPercentage(v)
+	case PPM:
+		return NewFromPPM(big.NewInt(v))
 	}
-	// The default unit is PPM
-	return NewFromPPM(big.NewInt(v))
+	// The default unit is PPB
+	return NewFromPPB(big.NewInt(v))
 }
 
 func newBPS(value *big.Int) *BPS {

--- a/bps/construct_test.go
+++ b/bps/construct_test.go
@@ -33,6 +33,11 @@ func TestOneAmountEquality(t *testing.T) {
 	if !oneAmt.Equal(ppm) {
 		t.Error("1 amount = 1000,000 ppm")
 	}
+
+	ppb := bps.NewFromPPB(big.NewInt(1000000000))
+	if !oneAmt.Equal(ppb) {
+		t.Error("1 amount = 1000,000,000 ppb")
+	}
 }
 
 func TestNewFromString(t *testing.T) {
@@ -269,32 +274,38 @@ func ExampleNewFromBaseUnit() {
 	deci := bps.NewFromBaseUnit(arg)
 	fmt.Println(deci.PPMs())
 
+	// BaseUnit is updated by PPB
+	bps.BaseUnit = bps.PPB
+	ppb := bps.NewFromBaseUnit(arg)
+	fmt.Println(ppb.PPBs())
+
 	// BaseUnit is updated by PPM
 	bps.BaseUnit = bps.PPM
 	ppm := bps.NewFromBaseUnit(arg)
-	fmt.Println(ppm.PPMs())
+	fmt.Println(ppm.PPBs())
 
 	// BaseUnit is updated by HalfBasisPoint
 	bps.BaseUnit = bps.HalfBasisPoint
 	hbp := bps.NewFromBaseUnit(arg)
-	fmt.Println(hbp.PPMs())
+	fmt.Println(hbp.PPBs())
 
 	// BaseUnit is updated by BasisPoint
 	bps.BaseUnit = bps.BasisPoint
 	bp := bps.NewFromBaseUnit(arg)
-	fmt.Println(bp.PPMs())
+	fmt.Println(bp.PPBs())
 
 	// BaseUnit is updated by Percentage
 	bps.BaseUnit = bps.Percentage
 	p := bps.NewFromBaseUnit(arg)
-	fmt.Println(p.PPMs())
+	fmt.Println(p.PPBs())
 
 	// teardown
 	bps.BaseUnit = u
 	// Output:
 	// 150
 	// 15
-	// 750
-	// 1500
-	// 150000
+	// 15000
+	// 750000
+	// 1500000
+	// 150000000
 }

--- a/bps/construct_test.go
+++ b/bps/construct_test.go
@@ -41,82 +41,65 @@ func TestOneAmountEquality(t *testing.T) {
 }
 
 func TestNewFromString(t *testing.T) {
-	tests := []struct {
-		name    string
+	tests := map[string]struct {
 		arg     string
 		want    *bps.BPS
 		wantErr bool
 	}{
-		{
-			"int part and decimal part",
+		"int part and decimal part": {
 			"123.456",
 			bps.NewFromBasisPoint(1234560),
 			false,
 		},
-		{
-			"only int part",
+		"only int part": {
 			"123",
 			bps.NewFromBasisPoint(1230000),
 			false,
 		},
-		{
-			"only decimal part",
+		"only decimal part": {
 			".1234",
 			bps.NewFromBasisPoint(1234),
 			false,
 		},
-		{
-			"negative value",
+		"negative value": {
 			"-123.456",
 			bps.NewFromBasisPoint(-1234560),
 			false,
 		},
-		{
-			"zero",
+		"zero": {
 			"0.0",
 			bps.NewFromAmount(0),
 			false,
 		},
-		{
-			"zero",
+		"short zero": {
 			".0",
 			bps.NewFromAmount(0),
 			false,
 		},
-		{
-			"If include multi dots, it should return an error",
+		"If include multi dots, it should return an error": {
 			"123.45.6",
 			nil,
 			true,
 		},
-		{
-			"If include multi dots, it should return an error",
-			"123.45.6",
-			nil,
-			true,
-		},
-		{
-			"If base 2 format, it should return an error",
+		"If base 2 format, it should return an error": {
 			"0b11",
 			nil,
 			true,
 		},
-		{
-			"If base 8 format, it should return an error",
+		"If base 8 format, it should return an error": {
 			"0o75",
 			nil,
 			true,
 		},
-		{
-			"If base 16 format, it should return an error",
+		"If base 16 format, it should return an error": {
 			"0xF5",
 			nil,
 			true,
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := bps.NewFromString(tt.arg)
 			if (err != nil) != tt.wantErr {
@@ -131,82 +114,65 @@ func TestNewFromString(t *testing.T) {
 }
 
 func TestMustFromString(t *testing.T) {
-	tests := []struct {
-		name      string
+	tests := map[string]struct {
 		arg       string
 		want      *bps.BPS
 		wantPanic bool
 	}{
-		{
-			"int part and decimal part",
+		"int part and decimal part": {
 			"123.456",
 			bps.NewFromBasisPoint(1234560),
 			false,
 		},
-		{
-			"only int part",
+		"only int part": {
 			"123",
 			bps.NewFromBasisPoint(1230000),
 			false,
 		},
-		{
-			"only decimal part",
+		"only decimal part": {
 			".1234",
 			bps.NewFromBasisPoint(1234),
 			false,
 		},
-		{
-			"negative value",
+		"negative value": {
 			"-123.456",
 			bps.NewFromBasisPoint(-1234560),
 			false,
 		},
-		{
-			"zero",
+		"zero": {
 			"0.0",
 			bps.NewFromAmount(0),
 			false,
 		},
-		{
-			"zero",
+		"short zero": {
 			".0",
 			bps.NewFromAmount(0),
 			false,
 		},
-		{
-			"If include multi dots, it should return an error",
+		"If include multi dots, it should return an error": {
 			"123.45.6",
 			nil,
 			true,
 		},
-		{
-			"If include multi dots, it should return an error",
-			"123.45.6",
-			nil,
-			true,
-		},
-		{
-			"If base 2 format, it should return an error",
+		"If base 2 format, it should return an error": {
 			"0b11",
 			nil,
 			true,
 		},
-		{
-			"If base 8 format, it should return an error",
+		"If base 8 format, it should return an error": {
 			"0o75",
 			nil,
 			true,
 		},
-		{
-			"If base 16 format, it should return an error",
+		"If base 16 format, it should return an error": {
 			"0xF5",
 			nil,
 			true,
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if tt.wantPanic {
 				//nolint:gocritic

--- a/bps/conv.go
+++ b/bps/conv.go
@@ -8,9 +8,14 @@ func (b *BPS) rawValue() *big.Int {
 	return new(big.Int).Set(s.value)
 }
 
+// PPBs returns the row value that means PPB.
+func (b *BPS) PPBs() *big.Int {
+	return b.rawValue()
+}
+
 // PPMs returns the row value that means PPM.
 func (b *BPS) PPMs() *big.Int {
-	return b.rawValue()
+	return b.Div(DenomPPM).rawValue()
 }
 
 // Amounts returns the basis point as an integer amount.
@@ -64,8 +69,10 @@ func (b *BPS) BaseUnitAmounts() *big.Int {
 		return b.BasisPoints()
 	case Percentage:
 		return b.Percentages()
+	case PPM:
+		return b.PPMs()
 	}
-	// default is PPM
+	// default is PPB
 	return b.rawValue()
 }
 

--- a/bps/conv_test.go
+++ b/bps/conv_test.go
@@ -10,35 +10,30 @@ import (
 )
 
 func TestBPS_Amounts(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  int64
 		want int64
 	}{
-		{
-			"1,000,000,000 ppbs equals 1 amount",
+		"1,000,000,000 ppbs equals 1 amount": {
 			1000000000,
 			1,
 		},
-		{
-			"1,999,999,999 ppbs equals 1 amount, round off fractions less than 100,000,000 ppbs",
+		"1,999,999,999 ppbs equals 1 amount, round off fractions less than 100,000,000 ppbs": {
 			1999999999,
 			1,
 		},
-		{
-			"2,000,000,000 ppbs equals 2 amounts",
+		"2,000,000,000 ppbs equals 2 amounts": {
 			2000000000,
 			2,
 		},
-		{
-			"999,999,999 ppbs equals zero amounts",
+		"999,999,999 ppbs equals zero amounts": {
 			999999999,
 			0,
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(big.NewInt(tt.ppb))
 			if got := b.Amounts(); got != tt.want {
@@ -49,40 +44,34 @@ func TestBPS_Amounts(t *testing.T) {
 }
 
 func TestBPS_Percentages(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  *big.Int
 		want *big.Int
 	}{
-		{
-			"1,000,000,000 ppbs equals 100 percentages",
+		"1,000,000,000 ppbs equals 100 percentages": {
 			big.NewInt(1000000000),
 			big.NewInt(100),
 		},
-		{
-			"1,009,999,999 ppbs equals 100 percentages, round off fractions less than 10,000,000 ppbs",
+		"1,009,999,999 ppbs equals 100 percentages, round off fractions less than 10,000,000 ppbs": {
 			big.NewInt(1009999999),
 			big.NewInt(100),
 		},
-		{
-			"1,010,000,000 ppbs equals 101 percentages",
+		"1,010,000,000 ppbs equals 101 percentages": {
 			big.NewInt(1010000000),
 			big.NewInt(101),
 		},
-		{
-			"10,000,000 ppbs equals 1 percentage",
+		"10,000,000 ppbs equals 1 percentage": {
 			big.NewInt(10000000),
 			big.NewInt(1),
 		},
-		{
-			"9,999,999 ppbs equals zero percentage",
+		"9,999,999 ppbs equals zero percentage": {
 			big.NewInt(999999),
 			big.NewInt(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(tt.ppb)
 			if got := b.Percentages(); !reflect.DeepEqual(got, tt.want) {
@@ -93,35 +82,30 @@ func TestBPS_Percentages(t *testing.T) {
 }
 
 func TestBPS_BasisPoints(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  *big.Int
 		want *big.Int
 	}{
-		{
-			"1,000,000,000 ppbs equals 10,000 basis points",
+		"1,000,000,000 ppbs equals 10,000 basis points": {
 			big.NewInt(1000000000),
 			big.NewInt(10000),
 		},
-		{
-			"1,000,099,999 ppbs equals 10,000 basis points, round off fractions less than 1,000,000 ppbs",
+		"1,000,099,999 ppbs equals 10,000 basis points, round off fractions less than 1,000,000 ppbs": {
 			big.NewInt(1000099999),
 			big.NewInt(10000),
 		},
-		{
-			"1,001,000,000 ppbs equals 10,001 basis points",
+		"1,001,000,000 ppbs equals 10,001 basis points": {
 			big.NewInt(1000100000),
 			big.NewInt(10001),
 		},
-		{
-			"99,999 ppbs equals zero basis points",
+		"99,999 ppbs equals zero basis points": {
 			big.NewInt(99999),
 			big.NewInt(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(tt.ppb)
 			if got := b.BasisPoints(); !reflect.DeepEqual(got, tt.want) {
@@ -132,35 +116,30 @@ func TestBPS_BasisPoints(t *testing.T) {
 }
 
 func TestBPS_HalfBasisPoints(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  *big.Int
 		want *big.Int
 	}{
-		{
-			"1,000,000,000 ppbs equals 20,000 half basis points",
+		"1,000,000,000 ppbs equals 20,000 half basis points": {
 			big.NewInt(1000000000),
 			big.NewInt(20000),
 		},
-		{
-			"1,000,049,999 ppbs equals 20,000 half basis points, round off fractions less than 50,000 ppbs",
+		"1,000,049,999 ppbs equals 20,000 half basis points, round off fractions less than 50,000 ppbs": {
 			big.NewInt(1000049999),
 			big.NewInt(20000),
 		},
-		{
-			"1,000,050,000 ppbs equals 20,001 half basis points",
+		"1,000,050,000 ppbs equals 20,001 half basis points": {
 			big.NewInt(1000050000),
 			big.NewInt(20001),
 		},
-		{
-			"49,999 ppbs equals zero half basis points",
+		"49,999 ppbs equals zero half basis points": {
 			big.NewInt(49999),
 			big.NewInt(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(tt.ppb)
 			if got := b.HalfBasisPoints(); !reflect.DeepEqual(got, tt.want) {
@@ -171,35 +150,30 @@ func TestBPS_HalfBasisPoints(t *testing.T) {
 }
 
 func TestBPS_DeciBasisPoints(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  *big.Int
 		want *big.Int
 	}{
-		{
-			"1,000,000,000 ppbs equals 100,000 deci basis points",
+		"1,000,000,000 ppbs equals 100,000 deci basis points": {
 			big.NewInt(1000000000),
 			big.NewInt(100000),
 		},
-		{
-			"1,000,009,999 ppbs equals 100,000 deci basis points, round off fractions less than 10,000 ppbs",
+		"1,000,009,999 ppbs equals 100,000 deci basis points, round off fractions less than 10,000 ppbs": {
 			big.NewInt(1000009999),
 			big.NewInt(100000),
 		},
-		{
-			"1,000,010,000 ppbs equals 100,001 deci basis points",
+		"1,000,010,000 ppbs equals 100,001 deci basis points": {
 			big.NewInt(1000010000),
 			big.NewInt(100001),
 		},
-		{
-			"9,999 ppbs equals zero deci basis points",
+		"9,999 ppbs equals zero deci basis points": {
 			big.NewInt(9999),
 			big.NewInt(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(tt.ppb)
 			if got := b.DeciBasisPoints(); !reflect.DeepEqual(got, tt.want) {
@@ -210,40 +184,34 @@ func TestBPS_DeciBasisPoints(t *testing.T) {
 }
 
 func TestBPS_PPMs(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  *big.Int
 		want *big.Int
 	}{
-		{
-			"1000,000 ppbs equals 1,000 ppms",
+		"1000,000 ppbs equals 1,000 ppms": {
 			big.NewInt(1000000),
 			big.NewInt(1000),
 		},
-		{
-			"1000 ppbs equals 1 ppms",
+		"1000 ppbs equals 1 ppms": {
 			big.NewInt(1000),
 			big.NewInt(1),
 		},
-		{
-			"1,999 ppbs equals 1 ppms, round off fractions less than 1,000 ppbs",
+		"1,999 ppbs equals 1 ppms, round off fractions less than 1,000 ppbs": {
 			big.NewInt(1999),
 			big.NewInt(1),
 		},
-		{
-			"2,001 ppbs equals 2 ppms",
+		"2,001 ppbs equals 2 ppms": {
 			big.NewInt(2001),
 			big.NewInt(2),
 		},
-		{
-			"999 ppbs equals 0 ppms",
+		"999 ppbs equals 0 ppms": {
 			big.NewInt(999),
 			big.NewInt(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(tt.ppb)
 			if got := b.PPMs(); !reflect.DeepEqual(got, tt.want) {
@@ -254,35 +222,30 @@ func TestBPS_PPMs(t *testing.T) {
 }
 
 func TestBPS_PPBs(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		ppb  *big.Int
 		want *big.Int
 	}{
-		{
-			"1,000 ppbs",
+		"1,000 ppbs": {
 			big.NewInt(1000),
 			big.NewInt(1000),
 		},
-		{
-			"1 ppbs",
+		"1 ppbs": {
 			big.NewInt(1),
 			big.NewInt(1),
 		},
-		{
-			"5 ppbs",
+		"5 ppbs": {
 			big.NewInt(5),
 			big.NewInt(5),
 		},
-		{
-			"nil equal 0 ppbs",
+		"nil equal 0 ppbs": {
 			nil,
 			big.NewInt(0),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			b := bps.NewFromPPB(tt.ppb)
 			if got := b.PPBs(); !reflect.DeepEqual(got, tt.want) {
@@ -293,55 +256,46 @@ func TestBPS_PPBs(t *testing.T) {
 }
 
 func TestBPS_Rat(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		want *big.Rat
 	}{
-		{
-			"10 ppbs = 1 / 100,000,000",
+		"10 ppbs = 1 / 100,000,000": {
 			bps.NewFromPPB(big.NewInt(10)),
 			big.NewRat(1, 100000000),
 		},
-		{
-			"10 ppms = 1 / 100,000",
+		"10 ppms = 1 / 100,000": {
 			bps.NewFromPPM(big.NewInt(10)),
 			big.NewRat(1, 100000),
 		},
-		{
-			"8 deci basis points = 8 / 100,000",
+		"8 deci basis points = 8 / 100,000": {
 			bps.NewFromDeciBasisPoint(8),
 			big.NewRat(8, 100000),
 		},
-		{
-			"5 basis points = 5 / 10,000",
+		"5 basis points = 5 / 10,000": {
 			bps.NewFromBasisPoint(5),
 			big.NewRat(5, 10000),
 		},
-		{
-			"5 basis points = 1 / 2,000",
+		"5 basis points = 1 / 2,000": {
 			bps.NewFromBasisPoint(5),
 			big.NewRat(1, 2000),
 		},
-		{
-			"20 percentages = 1 / 5",
+		"20 percentages = 1 / 5": {
 			bps.NewFromPercentage(20),
 			big.NewRat(1, 5),
 		},
-		{
-			"3 amounts = 3 / 1",
+		"3 amounts = 3 / 1": {
 			bps.NewFromAmount(3),
 			big.NewRat(3, 1),
 		},
-		{
-			"nil = 0",
+		"nil = 0": {
 			&bps.BPS{},
 			big.NewRat(0, 1),
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := tt.b.Rat(); got.Cmp(tt.want) != 0 {
 				t.Errorf("BPS.Rat() = %v, want %v", got, tt.want)
@@ -351,28 +305,25 @@ func TestBPS_Rat(t *testing.T) {
 }
 
 func TestBPS_Float64(t *testing.T) {
-	tests := []struct {
-		name      string
+	tests := map[string]struct {
 		b         *bps.BPS
 		wantF     float64
 		wantExact bool
 	}{
-		{
-			"1 / 4 can represent as float value exactly",
+		"1 / 4 can represent as float value exactly": {
 			bps.NewFromAmount(1).Div(4),
 			.25,
 			true,
 		},
-		{
-			"1 / 3 cannot represent as float value exactly",
+		"1 / 3 cannot represent as float value exactly": {
 			bps.NewFromAmount(1).Div(3),
 			.333333333,
 			false,
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			gotF, gotExact := tt.b.Float64()
 			if gotF != tt.wantF {

--- a/bps/conv_test.go
+++ b/bps/conv_test.go
@@ -12,27 +12,27 @@ import (
 func TestBPS_Amounts(t *testing.T) {
 	tests := []struct {
 		name string
-		ppm  int64
+		ppb  int64
 		want int64
 	}{
 		{
-			"1,000,000 ppms equals 1 amount",
-			1000000,
+			"1,000,000,000 ppbs equals 1 amount",
+			1000000000,
 			1,
 		},
 		{
-			"1,999,999 ppms equals 1 amount, round off fractions less than 100,000 ppms",
-			1999999,
+			"1,999,999,999 ppbs equals 1 amount, round off fractions less than 100,000,000 ppbs",
+			1999999999,
 			1,
 		},
 		{
-			"2,000,000 ppms equals 2 amounts",
-			2000000,
+			"2,000,000,000 ppbs equals 2 amounts",
+			2000000000,
 			2,
 		},
 		{
-			"999,999 ppms equals zero amounts",
-			999999,
+			"999,999,999 ppbs equals zero amounts",
+			999999999,
 			0,
 		},
 	}
@@ -40,7 +40,7 @@ func TestBPS_Amounts(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := bps.NewFromPPM(big.NewInt(tt.ppm))
+			b := bps.NewFromPPB(big.NewInt(tt.ppb))
 			if got := b.Amounts(); got != tt.want {
 				t.Errorf("BPS.Amounts() = %v, want %v", got, tt.want)
 			}
@@ -51,32 +51,32 @@ func TestBPS_Amounts(t *testing.T) {
 func TestBPS_Percentages(t *testing.T) {
 	tests := []struct {
 		name string
-		ppm  *big.Int
+		ppb  *big.Int
 		want *big.Int
 	}{
 		{
-			"1,000,000 ppms equals 100 percentages",
-			big.NewInt(1000000),
+			"1,000,000,000 ppbs equals 100 percentages",
+			big.NewInt(1000000000),
 			big.NewInt(100),
 		},
 		{
-			"1,009,999 ppms equals 100 percentages, round off fractions less than 10,000 ppms",
-			big.NewInt(1009999),
+			"1,009,999,999 ppbs equals 100 percentages, round off fractions less than 10,000,000 ppbs",
+			big.NewInt(1009999999),
 			big.NewInt(100),
 		},
 		{
-			"1,010,000 ppms equals 101 percentages",
-			big.NewInt(1010000),
+			"1,010,000,000 ppbs equals 101 percentages",
+			big.NewInt(1010000000),
 			big.NewInt(101),
 		},
 		{
-			"10,000 ppms equals 1 percentage",
-			big.NewInt(10000),
+			"10,000,000 ppbs equals 1 percentage",
+			big.NewInt(10000000),
 			big.NewInt(1),
 		},
 		{
-			"9,999 ppms equals zero percentage",
-			big.NewInt(9999),
+			"9,999,999 ppbs equals zero percentage",
+			big.NewInt(999999),
 			big.NewInt(0),
 		},
 	}
@@ -84,7 +84,7 @@ func TestBPS_Percentages(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := bps.NewFromPPM(tt.ppm)
+			b := bps.NewFromPPB(tt.ppb)
 			if got := b.Percentages(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BPS.Percentages() = %v, want %v", got, tt.want)
 			}
@@ -95,27 +95,27 @@ func TestBPS_Percentages(t *testing.T) {
 func TestBPS_BasisPoints(t *testing.T) {
 	tests := []struct {
 		name string
-		ppm  *big.Int
+		ppb  *big.Int
 		want *big.Int
 	}{
 		{
-			"1,000,000 ppms equals 10,000 basis points",
-			big.NewInt(1000000),
+			"1,000,000,000 ppbs equals 10,000 basis points",
+			big.NewInt(1000000000),
 			big.NewInt(10000),
 		},
 		{
-			"1,000,099 ppms equals 10,000 basis points, round off fractions less than 1,000 ppms",
-			big.NewInt(1000099),
+			"1,000,099,999 ppbs equals 10,000 basis points, round off fractions less than 1,000,000 ppbs",
+			big.NewInt(1000099999),
 			big.NewInt(10000),
 		},
 		{
-			"1,001,000 ppms equals 10,001 basis points",
-			big.NewInt(1000100),
+			"1,001,000,000 ppbs equals 10,001 basis points",
+			big.NewInt(1000100000),
 			big.NewInt(10001),
 		},
 		{
-			"99 ppms equals zero basis points",
-			big.NewInt(99),
+			"99,999 ppbs equals zero basis points",
+			big.NewInt(99999),
 			big.NewInt(0),
 		},
 	}
@@ -123,7 +123,7 @@ func TestBPS_BasisPoints(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := bps.NewFromPPM(tt.ppm)
+			b := bps.NewFromPPB(tt.ppb)
 			if got := b.BasisPoints(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BPS.BasisPoints() = %v, want %v", got, tt.want)
 			}
@@ -134,27 +134,27 @@ func TestBPS_BasisPoints(t *testing.T) {
 func TestBPS_HalfBasisPoints(t *testing.T) {
 	tests := []struct {
 		name string
-		ppm  *big.Int
+		ppb  *big.Int
 		want *big.Int
 	}{
 		{
-			"1,000,000 ppms equals 20,000 half basis points",
-			big.NewInt(1000000),
+			"1,000,000,000 ppbs equals 20,000 half basis points",
+			big.NewInt(1000000000),
 			big.NewInt(20000),
 		},
 		{
-			"1,000,049 ppms equals 20,000 half basis points, round off fractions less than 50 ppms",
-			big.NewInt(1000049),
+			"1,000,049,999 ppbs equals 20,000 half basis points, round off fractions less than 50,000 ppbs",
+			big.NewInt(1000049999),
 			big.NewInt(20000),
 		},
 		{
-			"1,000,050 ppms equals 20,001 half basis points",
-			big.NewInt(1000050),
+			"1,000,050,000 ppbs equals 20,001 half basis points",
+			big.NewInt(1000050000),
 			big.NewInt(20001),
 		},
 		{
-			"49 ppms equals zero half basis points",
-			big.NewInt(49),
+			"49,999 ppbs equals zero half basis points",
+			big.NewInt(49999),
 			big.NewInt(0),
 		},
 	}
@@ -162,7 +162,7 @@ func TestBPS_HalfBasisPoints(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := bps.NewFromPPM(tt.ppm)
+			b := bps.NewFromPPB(tt.ppb)
 			if got := b.HalfBasisPoints(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BPS.HalfBasisPoints() = %v, want %v", got, tt.want)
 			}
@@ -173,27 +173,27 @@ func TestBPS_HalfBasisPoints(t *testing.T) {
 func TestBPS_DeciBasisPoints(t *testing.T) {
 	tests := []struct {
 		name string
-		ppm  *big.Int
+		ppb  *big.Int
 		want *big.Int
 	}{
 		{
-			"1,000,000 ppms equals 100,000 deci basis points",
-			big.NewInt(1000000),
+			"1,000,000,000 ppbs equals 100,000 deci basis points",
+			big.NewInt(1000000000),
 			big.NewInt(100000),
 		},
 		{
-			"1,000,009 ppms equals 100,000 deci basis points, round off fractions less than 10 ppms",
-			big.NewInt(1000009),
+			"1,000,009,999 ppbs equals 100,000 deci basis points, round off fractions less than 10,000 ppbs",
+			big.NewInt(1000009999),
 			big.NewInt(100000),
 		},
 		{
-			"1,000,010 ppms equals 100,001 deci basis points",
-			big.NewInt(1000010),
+			"1,000,010,000 ppbs equals 100,001 deci basis points",
+			big.NewInt(1000010000),
 			big.NewInt(100001),
 		},
 		{
-			"9 ppms equals zero deci basis points",
-			big.NewInt(9),
+			"9,999 ppbs equals zero deci basis points",
+			big.NewInt(9999),
 			big.NewInt(0),
 		},
 	}
@@ -201,7 +201,7 @@ func TestBPS_DeciBasisPoints(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := bps.NewFromPPM(tt.ppm)
+			b := bps.NewFromPPB(tt.ppb)
 			if got := b.DeciBasisPoints(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BPS.DeciBasisPoints() = %v, want %v", got, tt.want)
 			}
@@ -212,26 +212,70 @@ func TestBPS_DeciBasisPoints(t *testing.T) {
 func TestBPS_PPMs(t *testing.T) {
 	tests := []struct {
 		name string
-		ppm  *big.Int
+		ppb  *big.Int
 		want *big.Int
 	}{
 		{
-			"1,000 ppms",
+			"1000,000 ppbs equals 1,000 ppms",
+			big.NewInt(1000000),
+			big.NewInt(1000),
+		},
+		{
+			"1000 ppbs equals 1 ppms",
+			big.NewInt(1000),
+			big.NewInt(1),
+		},
+		{
+			"1,999 ppbs equals 1 ppms, round off fractions less than 1,000 ppbs",
+			big.NewInt(1999),
+			big.NewInt(1),
+		},
+		{
+			"2,001 ppbs equals 2 ppms",
+			big.NewInt(2001),
+			big.NewInt(2),
+		},
+		{
+			"999 ppbs equals 0 ppms",
+			big.NewInt(999),
+			big.NewInt(0),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := bps.NewFromPPB(tt.ppb)
+			if got := b.PPMs(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BPS.PPMs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBPS_PPBs(t *testing.T) {
+	tests := []struct {
+		name string
+		ppb  *big.Int
+		want *big.Int
+	}{
+		{
+			"1,000 ppbs",
 			big.NewInt(1000),
 			big.NewInt(1000),
 		},
 		{
-			"1 ppms",
+			"1 ppbs",
 			big.NewInt(1),
 			big.NewInt(1),
 		},
 		{
-			"5 ppms",
+			"5 ppbs",
 			big.NewInt(5),
 			big.NewInt(5),
 		},
 		{
-			"nil equal 0 ppms",
+			"nil equal 0 ppbs",
 			nil,
 			big.NewInt(0),
 		},
@@ -240,8 +284,8 @@ func TestBPS_PPMs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			b := bps.NewFromPPM(tt.ppm)
-			if got := b.PPMs(); !reflect.DeepEqual(got, tt.want) {
+			b := bps.NewFromPPB(tt.ppb)
+			if got := b.PPBs(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BPS.PPMs() = %v, want %v", got, tt.want)
 			}
 		})
@@ -254,6 +298,11 @@ func TestBPS_Rat(t *testing.T) {
 		b    *bps.BPS
 		want *big.Rat
 	}{
+		{
+			"10 ppbs = 1 / 100,000,000",
+			bps.NewFromPPB(big.NewInt(10)),
+			big.NewRat(1, 100000000),
+		},
 		{
 			"10 ppms = 1 / 100,000",
 			bps.NewFromPPM(big.NewInt(10)),
@@ -317,7 +366,7 @@ func TestBPS_Float64(t *testing.T) {
 		{
 			"1 / 3 cannot represent as float value exactly",
 			bps.NewFromAmount(1).Div(3),
-			.333333,
+			.333333333,
 			false,
 		},
 	}
@@ -345,6 +394,10 @@ func ExampleBPS_BaseUnitAmounts() {
 	// The default BaseUnit is DeciBasisPoint
 	fmt.Println(b.BaseUnitAmounts())
 
+	// BaseUnit is updated by PPB
+	bps.BaseUnit = bps.PPB
+	fmt.Println(b.BaseUnitAmounts())
+
 	// BaseUnit is updated by PPM
 	bps.BaseUnit = bps.PPM
 	fmt.Println(b.BaseUnitAmounts())
@@ -365,6 +418,7 @@ func ExampleBPS_BaseUnitAmounts() {
 	bps.BaseUnit = u
 	// Output:
 	// 15000
+	// 150000000
 	// 150000
 	// 3000
 	// 1500

--- a/bps/serial_test.go
+++ b/bps/serial_test.go
@@ -9,25 +9,22 @@ import (
 )
 
 func TestBPS_Value(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		b    *bps.BPS
 		want driver.Value
 	}{
-		{
-			"zero",
+		"zero": {
 			bps.NewFromAmount(0),
 			"0",
 		},
-		{
-			"1 amount",
+		"1 amount": {
 			bps.NewFromAmount(1),
 			"100000",
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			got, err := tt.b.Value()
 			if err != nil {
 				t.Errorf("BPS.Value() error = %v", err)
@@ -41,87 +38,76 @@ func TestBPS_Value(t *testing.T) {
 }
 
 func TestBPS_Scan(t *testing.T) {
-	tests := []struct {
-		name    string
+	tests := map[string]struct {
 		b       *bps.BPS
 		value   interface{}
 		want    *bps.BPS
 		wantErr bool
 	}{
-		{
-			"If b is nil, it should return an error",
+		"If b is nil, it should return an error": {
 			nil,
 			"fake",
 			nil,
 			true,
 		},
-		{
-			"If value is uint, it should set value as DeciBasisPoint",
+		"If value is uint, it should set value as DeciBasisPoint": {
 			&bps.BPS{},
 			uint(5),
 			bps.NewFromDeciBasisPoint(5),
 			false,
 		},
-		{
-			"If value is uint32, it should set value as DeciBasisPoint",
+		"If value is uint32, it should set value as DeciBasisPoint": {
 			&bps.BPS{},
 			uint32(6),
 			bps.NewFromDeciBasisPoint(6),
 			false,
 		},
-		{
-			"If value is uint64, it should set value as DeciBasisPoint",
+		"If value is uint64, it should set value as DeciBasisPoint": {
 			&bps.BPS{},
 			uint64(7),
 			bps.NewFromDeciBasisPoint(7),
 			false,
 		},
-		{
-			"If value is int, it should set value as DeciBasisPoint",
+		"If value is int, it should set value as DeciBasisPoint": {
 			&bps.BPS{},
 			int(6),
 			bps.NewFromDeciBasisPoint(6),
 			false,
 		},
-		{
-			"If value is int32, it should set value as DeciBasisPoint",
+		"If value is int32, it should set value as DeciBasisPoint": {
 			&bps.BPS{},
 			int32(7),
 			bps.NewFromDeciBasisPoint(7),
 			false,
 		},
-		{
-			"If value is int64, it should set value as DeciBasisPoint",
+		"If value is int64, it should set value as DeciBasisPoint": {
 			&bps.BPS{},
 			int64(8),
 			bps.NewFromDeciBasisPoint(8),
 			false,
 		},
-		{
-			"If value is valid string, it should set value via NewFromString",
+		"If value is valid string, it should set value via NewFromString": {
 			&bps.BPS{},
 			".15",
 			bps.NewFromPercentage(15),
 			false,
 		},
-		{
-			"If value is invalid string, it should return an error",
+		"If value is invalid string, it should return an error": {
 			&bps.BPS{},
 			"a15",
 			&bps.BPS{},
 			true,
 		},
-		{
-			"If value is float, it should return an error",
+		"If value is float, it should return an error": {
 			&bps.BPS{},
 			.5,
 			&bps.BPS{},
 			true,
 		},
 	}
-	for _, tt := range tests {
+	for name, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if err := tt.b.Scan(tt.value); (err != nil) != tt.wantErr {
 				t.Errorf("BPS.Scan() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Cloud Spanner's [NUMERIC type](https://cloud.google.com/spanner/docs/working-with-numerics#go) supports the numeric value with the scale of 9.
So, this package adopts the parts per billion(PPB) instead of PPM as the base unit.