### PR TITLE
bps: remove unnecessary name capture

### DIFF
--- a/bps/serial_test.go
+++ b/bps/serial_test.go
@@ -158,7 +158,6 @@ func TestBPS_UnmarshalText(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		name := name
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Remove unnecessary `name` capture.

The `name` variable is not used in the sub-test. No needs captured.